### PR TITLE
停止deploy Tensu-demo網站

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,3 @@ deploy:
       tags: true
       repo: i3thuan5/TenSu
       condition: $TSI2_LING7 = build
-  - provider: pages
-    fqdn: tensu.ithuan.tw
-    skip_cleanup: true
-    local_dir: build/
-    github_token:
-      secure: QbIUQuRB07UGLtAJAIOJKbZN4EIwSmzyTuWeiy9UGoMi95b+bEhg/+NXePwoyoHu/PdExjY5IdMZCfH6tEpRMeOtHgWaCS90ezsaF7vA1zoGeXsJAMZexhjLDIXcB+yAMsdROMO0tggCxv3zesgEQgq3I/09eLvXtIpzuelys+1hQ2K4/IOWUcA/ypvJmKi0sQGoVNOK8j3sNZVFS1hnwDrHWa5BCsT0bKAr9Opa3Ju+sc/CD0zJhunV1dCHNLCmUmOi1I9i54JLFGt/Dt0wdLyy1dEni6cpPJcoMsrNaYJxebtyWqfu8WYP8JQg1HUqn6UpezXEvxq+asGcE/6qwQA8UlqJxvKxBV3/lViHMeDe6D6gFtkcyDysG/rIorlaD7eDc/ntgTFsvmee08rQa38PQDmEz3ViB2IU+W34v1OUh7oXkr2T/ExFK+98PcSj6sAipSftj21idtj+c0+rN7lWmMJwaWlOaRqk2kAZmPUd745Wuy84golN7IXNKHobihgNHMlZWgNTAGyj/eitlCN3yPg7Jyla1t1bhRkC6u3rqMFuwD1mwtpnyspDp7aJTws3ErpSldQRNw20Drv/CJIXLt01Hw+RhqrHwVgpQ+tD/NOttc0q4LKYcI/hKH/NK5TIU6Y4GaO6h4u3QUJRu7ePKrsKCt+wPFDJUUI+bxw=
-    on:
-      branch: master
-      condition: $TSI2_LING7 = build


### PR DESCRIPTION
因為無按算維護客話網站，免deploy，github page deploy key就做伙piànn掉。