### PR TITLE
修Github Page deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,25 @@ env:
 branches:
   only:
   - master
-  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+  # - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 script:
 - echo npm run $TSI2_LING7
 - npm run $TSI2_LING7
 deploy:
-  - provider: npm
-    skip_cleanup: true
-    email: a8568730@gmail.com
-    api_key:
-      secure: BZDiOrzQiWUo8u+B1ux5w7QjWzJBe3E7MuFt0CJseuSJilyf/OIX4M09kOcyheSBZLOI8o21+UTPquK9A6qqLfiA5rHYCXwRF4zGcawBr8tQYHfDeZbFFqfWAvlgQso0DmrvN3CT0KgxiHCG6hEQ2WNEwvSnXMlaJTHwcom/F7/C9Xl9POKoG2FzYetQ7XYKryZsQquSc9NymFvo+erYS8AXf0CM1TmfbThzEuVoh/N6APOWTwj0rVW1qJ8prlE08tiAqkMAUG7Bg3Op+/He8fTTY7wQvQmdzYnydnUkPpziTzXwEUjHHyJWRZ+LbuAG/v6/eEyv9Pv4cv7Mr7p+VU3ABKOznZ0ZRTGpl6i40MwFYQ62KRnqyAnZMc70eILcnGIpoMx3ZCti7EggB4lBckJU7XtCC94U2TZ+fevnuPzh47z0C8xLxknIPO6+pb9oEmfVHTyM3CJ5JEzI2jbI60CcsTnietVBO0p6ZFFm2dyLs6qaxodmSzwWwDLIdDD/uSXoG1wUFB697F71v6yJnuyhdd2NKZK1huKBONuThrYW1sRGnP9WKvy/aknP/81mhy1mKtaQuM4Ii2L9tHlux8pe1MlBRw/ACFc/oIHUup031J21Ok8/ZH8zw2S/0EfQ902TnMQibbPSIloz5BHzQLCFRrSSlG7E//ZJc0A4cmE=
-    on:
-      tags: true
-      repo: i3thuan5/TenSu
-      condition: $TSI2_LING7 = build
+  # - provider: npm
+  #   skip_cleanup: true
+  #   email: a8568730@gmail.com
+  #   api_key:
+  #     secure: BZDiOrzQiWUo8u+B1ux5w7QjWzJBe3E7MuFt0CJseuSJilyf/OIX4M09kOcyheSBZLOI8o21+UTPquK9A6qqLfiA5rHYCXwRF4zGcawBr8tQYHfDeZbFFqfWAvlgQso0DmrvN3CT0KgxiHCG6hEQ2WNEwvSnXMlaJTHwcom/F7/C9Xl9POKoG2FzYetQ7XYKryZsQquSc9NymFvo+erYS8AXf0CM1TmfbThzEuVoh/N6APOWTwj0rVW1qJ8prlE08tiAqkMAUG7Bg3Op+/He8fTTY7wQvQmdzYnydnUkPpziTzXwEUjHHyJWRZ+LbuAG/v6/eEyv9Pv4cv7Mr7p+VU3ABKOznZ0ZRTGpl6i40MwFYQ62KRnqyAnZMc70eILcnGIpoMx3ZCti7EggB4lBckJU7XtCC94U2TZ+fevnuPzh47z0C8xLxknIPO6+pb9oEmfVHTyM3CJ5JEzI2jbI60CcsTnietVBO0p6ZFFm2dyLs6qaxodmSzwWwDLIdDD/uSXoG1wUFB697F71v6yJnuyhdd2NKZK1huKBONuThrYW1sRGnP9WKvy/aknP/81mhy1mKtaQuM4Ii2L9tHlux8pe1MlBRw/ACFc/oIHUup031J21Ok8/ZH8zw2S/0EfQ902TnMQibbPSIloz5BHzQLCFRrSSlG7E//ZJc0A4cmE=
+  #   on:
+  #     tags: true
+  #     repo: i3thuan5/TenSu-Demo
+  #     condition: $TSI2_LING7 = build
   - provider: pages
     fqdn: tensu.ithuan.tw
     skip_cleanup: true
     local_dir: build/
-    github_token:
-      secure: QbIUQuRB07UGLtAJAIOJKbZN4EIwSmzyTuWeiy9UGoMi95b+bEhg/+NXePwoyoHu/PdExjY5IdMZCfH6tEpRMeOtHgWaCS90ezsaF7vA1zoGeXsJAMZexhjLDIXcB+yAMsdROMO0tggCxv3zesgEQgq3I/09eLvXtIpzuelys+1hQ2K4/IOWUcA/ypvJmKi0sQGoVNOK8j3sNZVFS1hnwDrHWa5BCsT0bKAr9Opa3Ju+sc/CD0zJhunV1dCHNLCmUmOi1I9i54JLFGt/Dt0wdLyy1dEni6cpPJcoMsrNaYJxebtyWqfu8WYP8JQg1HUqn6UpezXEvxq+asGcE/6qwQA8UlqJxvKxBV3/lViHMeDe6D6gFtkcyDysG/rIorlaD7eDc/ntgTFsvmee08rQa38PQDmEz3ViB2IU+W34v1OUh7oXkr2T/ExFK+98PcSj6sAipSftj21idtj+c0+rN7lWmMJwaWlOaRqk2kAZmPUd745Wuy84golN7IXNKHobihgNHMlZWgNTAGyj/eitlCN3yPg7Jyla1t1bhRkC6u3rqMFuwD1mwtpnyspDp7aJTws3ErpSldQRNw20Drv/CJIXLt01Hw+RhqrHwVgpQ+tD/NOttc0q4LKYcI/hKH/NK5TIU6Y4GaO6h4u3QUJRu7ePKrsKCt+wPFDJUUI+bxw=
+    github_token: ${GITHUB_TOKEN}
     on:
       branch: master
       condition: $TSI2_LING7 = build


### PR DESCRIPTION
master https://github.com/i3thuan5/TenSu-Demo/commit/ddb2c36e2dbfce64036f9218f1aaf6e796886646 害去。Deploy npm、Github Page攏失敗。

CI 警告：
```
Skipping a deployment with the npm provider because this repo's name does not match one specified in 
.travis.yml's deploy.on.repo: i3thuan5/TenSu

Skipping a deployment with the npm provider because this is not a tagged commit
dpl_1

DEPRECATION WARNING! We are moving to dpl v.2. If you want to preserve the current behavior 
and still use dpl v.1, add the dpl_version key with the desired version of the dpl gem 
(the last stable is 1.10.16)  to your .travis.yml.

Installing deploy dependencies
gh-token is invalid. Details: GET https://api.github.com/user: 401 - Bad credentials 
// See: https://docs.github.com/rest
```

npm部份，免處理。咱處理下底Github Page，Travis CI申請Github Personal access tokens (classic)予TenSu、Hapuy落線用（[申請單](https://github.com/i3thuan5/TsuAn-BunKiann/issues/1160)）更新Github Token。